### PR TITLE
Fix buttons

### DIFF
--- a/spacenav/include/spacenav/spacenav.hpp
+++ b/spacenav/include/spacenav/spacenav.hpp
@@ -84,6 +84,8 @@ private:
   double normed_wx = 0;
   double normed_wy = 0;
   double normed_wz = 0;
+
+  sensor_msgs::msg::Joy msg_joystick;
 };
 
 }  // namespace spacenav

--- a/spacenav/src/spacenav.cpp
+++ b/spacenav/src/spacenav.cpp
@@ -112,6 +112,11 @@ Spacenav::Spacenav(const rclcpp::NodeOptions & options)
   callback_handler =
     this->add_on_set_parameters_callback(param_change_callback);
 
+  // Prepare the default joystick message.
+  // We'll resize dynamically to support spacenav devices with more buttons.
+  constexpr int min_buttons = 2;
+  msg_joystick.buttons.resize(min_buttons);
+
   // Setup publishers and Timer
   publisher_offset = this->create_publisher<geometry_msgs::msg::Vector3>(
     "spacenav/offset", 10);
@@ -203,8 +208,7 @@ void Spacenav::poll_spacenav()
 
   bool queue_empty = false;
   while (!queue_empty) {
-    auto msg_joystick = std::make_unique<sensor_msgs::msg::Joy>();
-    msg_joystick->header.stamp = get_clock()->now();
+    msg_joystick.header.stamp = get_clock()->now();
     // Output changes each time a button event happens, or when a motion
     // event happens and the queue is empty.
 
@@ -246,10 +250,23 @@ void Spacenav::poll_spacenav()
         break;
 
       case SPNAV_EVENT_BUTTON:
-        if (sev.button.bnum >= static_cast<int>(msg_joystick->buttons.size())) {
-          msg_joystick->buttons.resize(sev.button.bnum + 1);
+
+        if (sev.button.bnum < 0)
+        {
+          RCLCPP_WARN(get_logger(), "Negative spacenav buttons not supported. Got %i", sev.button.bnum);
+          break;
         }
-        msg_joystick->buttons[sev.button.bnum] = sev.button.press;
+        if (sev.button.bnum < static_cast<int>(msg_joystick.buttons.size()))
+        {
+          // Update known buttons
+          msg_joystick.buttons[sev.button.bnum] = sev.button.press;
+        }
+        else
+        {
+          // Enlarge, fill up with zeros, and support the new button
+          msg_joystick.buttons.resize(sev.button.bnum + 1, 0);
+          msg_joystick.buttons[sev.button.bnum] = sev.button.press;
+        }
         joy_stale = true;
         break;
 
@@ -285,15 +302,15 @@ void Spacenav::poll_spacenav()
       joy_stale = true;
     }
     if (joy_stale) {
-      msg_joystick->axes.resize(6);
+      msg_joystick.axes.resize(6);
       // The joystick.axes are normalized within [-1, 1].
-      msg_joystick->axes[0] = normed_vx;
-      msg_joystick->axes[1] = normed_vy;
-      msg_joystick->axes[2] = normed_vz;
-      msg_joystick->axes[3] = normed_wx;
-      msg_joystick->axes[4] = normed_wy;
-      msg_joystick->axes[5] = normed_wz;
-      publisher_joy->publish(std::move(msg_joystick));
+      msg_joystick.axes[0] = normed_vx;
+      msg_joystick.axes[1] = normed_vy;
+      msg_joystick.axes[2] = normed_vz;
+      msg_joystick.axes[3] = normed_wx;
+      msg_joystick.axes[4] = normed_wy;
+      msg_joystick.axes[5] = normed_wz;
+      publisher_joy->publish(msg_joystick);
     }
   }
 }

--- a/spacenav/src/spacenav.cpp
+++ b/spacenav/src/spacenav.cpp
@@ -251,18 +251,15 @@ void Spacenav::poll_spacenav()
 
       case SPNAV_EVENT_BUTTON:
 
-        if (sev.button.bnum < 0)
-        {
-          RCLCPP_WARN(get_logger(), "Negative spacenav buttons not supported. Got %i", sev.button.bnum);
+        if (sev.button.bnum < 0) {
+          RCLCPP_WARN(
+            get_logger(), "Negative spacenav buttons not supported. Got %i", sev.button.bnum);
           break;
         }
-        if (sev.button.bnum < static_cast<int>(msg_joystick.buttons.size()))
-        {
+        if (sev.button.bnum < static_cast<int>(msg_joystick.buttons.size())) {
           // Update known buttons
           msg_joystick.buttons[sev.button.bnum] = sev.button.press;
-        }
-        else
-        {
+        } else {
           // Enlarge, fill up with zeros, and support the new button
           msg_joystick.buttons.resize(sev.button.bnum + 1, 0);
           msg_joystick.buttons[sev.button.bnum] = sev.button.press;


### PR DESCRIPTION
## Problem
The spacenav buttons are currently only published once upon being triggered. They are thus flooded by the other, continuously published motion events.

## Approach

We now always publish the two default button states, in which
0 = not pressed
1 = pressed.

That's the previously known ROS1 behavior.

Additional buttons emerge and stay in that list upon being pressed for the first time.  This supports more advanced spacenav devices with a yet unknown number of buttons.

Fixes #223

---

## What the fix looks like
`ros2 topic echo /spacenav/joy`:
No buttons pressed:
![Screenshot from 2022-11-15 15-38-49](https://user-images.githubusercontent.com/20354653/201947986-bc414b7a-119e-4a1f-abe5-aee734e117d6.png)

Both buttons pressed:
![Screenshot from 2022-11-15 15-41-14](https://user-images.githubusercontent.com/20354653/201947998-2567be85-7360-4069-a29b-b8bd6ce0b77a.png)


